### PR TITLE
eip-7547

### DIFF
--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -174,6 +174,8 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         block_logs_bloom,
         state,
         withdrawals_root,
+        inclusion_list_summary_root,
+        inclusion_list_exclusions_root,
     ) = apply_body(
         chain.state,
         get_last_256_block_hashes(chain),
@@ -186,6 +188,8 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         block.transactions,
         chain.chain_id,
         block.withdrawals,
+        block.inclusion_list_summary,
+        block.inclusion_list_exclusions,
     )
     ensure(gas_used == block.header.gas_used, InvalidBlock)
     ensure(transactions_root == block.header.transactions_root, InvalidBlock)
@@ -193,6 +197,8 @@ def state_transition(chain: BlockChain, block: Block) -> None:
     ensure(receipt_root == block.header.receipt_root, InvalidBlock)
     ensure(block_logs_bloom == block.header.bloom, InvalidBlock)
     ensure(withdrawals_root == block.header.withdrawals_root, InvalidBlock)
+    ensure(inclusion_list_summary_root == block.header.inclusion_list_summary_root, InvalidBlock)
+    ensure(inclusion_list_exclusions_root == block.header.inclusion_list_exclusions_root, InvalidBlock)
 
     chain.blocks.append(block)
     if len(chain.blocks) > 255:
@@ -411,7 +417,9 @@ def apply_body(
     transactions: Tuple[Union[LegacyTransaction, Bytes], ...],
     chain_id: U64,
     withdrawals: Tuple[Withdrawal, ...],
-) -> Tuple[Uint, Root, Root, Bloom, State, Root]:
+    inclusion_list_summary: Tuple[InclusionListSummaryEntry, ...],
+    inclusion_list_exclusions: Tuple[Uint, ...],
+) -> Tuple[Uint, Root, Root, Bloom, State, Root, Root, Root]:
     """
     Executes a block.
 

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -143,7 +143,7 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
     return recent_block_hashes
 
 
-def state_transition(chain: BlockChain, block: Block) -> None:
+def state_transition(chain: BlockChain, parent, block: Block) -> None:
     """
     Attempts to apply a block to an existing block chain.
 
@@ -165,7 +165,6 @@ def state_transition(chain: BlockChain, block: Block) -> None:
     block :
         Block to apply to `chain`.
     """
-    parent = chain.blocks[-1]
     validate_header(block.header, parent.header)
     ensure(block.ommers == (), InvalidBlock)
     parent_transactions_addresses = [decode_transaction(tx).address for tx in parent.transactions]

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -548,7 +548,7 @@ def apply_body(
         if sender_address in inclusion_list_addresses:
             # Mark this address as satisfied
             inclusion_list_addresses[sender_address] = True
-            # Subtract gas used in the IL transaction.
+            # Subtract gas used in the transaction from the IL limit.
             il_gas_available -= gas_used
             if il_gas_available < 0:
                 raise InvalidBlock

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -470,6 +470,9 @@ def apply_body(
     state : `ethereum.fork_types.State`
         State after all transactions have been executed.
     """
+    if inclusion_list_summary.parent_hash != block_hashes[-1]:
+        raise InvalidBlock
+
     # Construct a map of addresses required.
     inclusion_list_nonces = {entry.address : 0 for entry in inclusion_list_summary}
 

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -473,8 +473,8 @@ def apply_body(
     # Construct a map of addresses required.
     inclusion_list_nonces = {entry.address : 0 for entry in inclusion_list_summary}
 
-    gas_available = block_gas_limit
     il_gas_available = INCLUSION_LIST_GAS
+    gas_available = block_gas_limit + il_gas_available
 
     transactions_trie: Trie[
         Bytes, Optional[Union[Bytes, LegacyTransaction]]
@@ -538,7 +538,7 @@ def apply_body(
         set_parent_transactions_addresses_calldata += sender_address
         block_logs += logs
 
-    block_gas_used = block_gas_limit - gas_available
+    block_gas_used = block_gas_limit - gas_available - il_gas_available
 
     block_logs_bloom = logs_bloom(block_logs)
 

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -150,7 +150,7 @@ def get_last_256_block_hashes(chain: BlockChain) -> List[Hash32]:
     return recent_block_hashes
 
 
-def state_transition(chain: BlockChain, parent, block: Block) -> None:
+def state_transition(chain: BlockChain, block: Block) -> None:
     """
     Attempts to apply a block to an existing block chain.
 

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -59,15 +59,22 @@ from .state import (
     state_root,
 )
 from .trie import Trie, root, trie_set
+from .utils.hexadecimal import hex_to_address
 from .utils.message import prepare_message
+from .vm import Message, Evm
 from .vm.gas import init_code_cost
-from .vm.interpreter import MAX_CODE_SIZE, process_message_call
+from .vm.interpreter import MAX_CODE_SIZE, process_message_call, process_message
 
 BASE_FEE_MAX_CHANGE_DENOMINATOR = 8
 ELASTICITY_MULTIPLIER = 2
 GAS_LIMIT_ADJUSTMENT_FACTOR = 1024
 GAS_LIMIT_MINIMUM = 5000
 EMPTY_OMMER_HASH = keccak256(rlp.encode([]))
+SYSTEM_ADDRESS = hex_to_address("0xfffffffffffffffffffffffffffffffffffffffe")
+PARENT_TRANSACTIONS_ADDRESSES_ADDRESS = hex_to_address(
+    "tbd_system_contract_address"
+)
+SYSTEM_TRANSACTION_GAS = Uint(30000000)
 
 
 @dataclass
@@ -470,7 +477,28 @@ def apply_body(
     state : `ethereum.fork_types.State`
         State after all transactions have been executed.
     """
+    # To be used both by parent beacon block root and parent transaction addresses system calls
+    system_tx_env = vm.Environment(
+        caller=SYSTEM_ADDRESS,
+        origin=SYSTEM_ADDRESS,
+        block_hashes=block_hashes,
+        coinbase=coinbase,
+        number=block_number,
+        gas_limit=block_gas_limit,
+        base_fee_per_gas=base_fee_per_gas,
+        gas_price=base_fee_per_gas,
+        time=block_time,
+        prev_randao=prev_randao,
+        state=state,
+        chain_id=chain_id,
+        traces=[],
+    )
 
+    # Recover parent transaction addresses from the state
+    parent_transactions_addresses = get_parent_transactions_addresses_system_call(state, system_tx_env)
+    # Filter out IL addresses already included in the parent
+    inclusion_list_summary = [entry for entry in inclusion_list_summary 
+                              if entry.address not in parent_transactions_addresses]
     # Calculate the additional gas added by the inclusion list and construct
     # a map of addresses required.
     inclusion_list_gas = sum(entry.gas_limit for entry in inclusion_list_summary)
@@ -488,6 +516,8 @@ def apply_body(
         secured=False, default=None
     )
     block_logs: Tuple[Log, ...] = ()
+
+    set_parent_transactions_addresses_calldata: Bytes = Uint(len(transactions)).to_be_bytes32()
 
     for i, tx in enumerate(map(decode_transaction, transactions)):
         trie_set(
@@ -532,6 +562,7 @@ def apply_body(
             receipt,
         )
 
+        set_parent_transactions_addresses_calldata += sender_address
         block_logs += logs
 
     block_gas_used = block_gas_limit - gas_available
@@ -550,6 +581,8 @@ def apply_body(
     for entry in inclusion_list_addresses:
         if inclusion_list_addresses[entry] is False:
             raise InvalidBlock
+
+    set_parent_transactions_addresses_system_call(state, set_parent_transactions_addresses_calldata, system_tx_env)
 
     return (
         block_gas_used,
@@ -1002,4 +1035,34 @@ def check_gas_limit(gas_limit: Uint, parent_gas_limit: Uint) -> bool:
 
     return True
 
+def parent_transactions_addresses_system_call(state: State, data: Bytes, system_tx_env: vm.Environment) -> Evm:
+    parent_transactions_addresses_contract_code = get_account(
+        state, PARENT_TRANSACTIONS_ADDRESSES_ADDRESS
+    ).code
 
+    system_tx_message = Message(
+        caller=SYSTEM_ADDRESS,
+        target=PARENT_TRANSACTIONS_ADDRESSES_ADDRESS,
+        gas=SYSTEM_TRANSACTION_GAS,
+        value=U256(0),
+        data=data,
+        code=parent_transactions_addresses_contract_code,
+        depth=Uint(0),
+        current_target=PARENT_TRANSACTIONS_ADDRESSES_ADDRESS,
+        code_address=PARENT_TRANSACTIONS_ADDRESSES_ADDRESS,
+        should_transfer_value=False,
+        is_static=False,
+        accessed_addresses=set(),
+        accessed_storage_keys=set(),
+        parent_evm=None,
+    )
+
+    return process_message(system_tx_message, system_tx_env) 
+
+
+def get_parent_transactions_addresses_system_call(state: State, system_tx_env: vm.Environment) -> List[Address]:
+    evm = parent_transactions_addresses_system_call(state=state, data=b'', system_tx_env=system_tx_env)
+    return [Address(evm.output[i:i+20]) for i in range(0, len(evm.output) // 20)]
+
+def set_parent_transactions_addresses_system_call(state: State, data: Bytes, system_tx_env: vm.Environment) -> None:
+    parent_transactions_addresses_system_call(state=state, data=data, system_tx_env=system_tx_env)

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -172,11 +172,9 @@ def state_transition(chain: BlockChain, block: Block) -> None:
     block :
         Block to apply to `chain`.
     """
-    validate_header(block.header, parent.header)
+    parent_header = chain.blocks[-1].header
+    validate_header(block.header, parent_header)
     ensure(block.ommers == (), InvalidBlock)
-    parent_transactions_addresses = [decode_transaction(tx).address for tx in parent.transactions]
-    inclusion_list_summary = [entry for entry in block.inclusion_list_summary 
-                              if entry.address not in parent_transactions_addresses]
     (
         gas_used,
         transactions_root,
@@ -196,7 +194,7 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         block.transactions,
         chain.chain_id,
         block.withdrawals,
-        inclusion_list_summary,
+        block.inclusion_list_summary,
     )
     ensure(gas_used == block.header.gas_used, InvalidBlock)
     ensure(transactions_root == block.header.transactions_root, InvalidBlock)

--- a/src/ethereum/shanghai/fork.py
+++ b/src/ethereum/shanghai/fork.py
@@ -174,8 +174,6 @@ def state_transition(chain: BlockChain, block: Block) -> None:
         block_logs_bloom,
         state,
         withdrawals_root,
-        inclusion_list_summary_root,
-        inclusion_list_exclusions_root,
     ) = apply_body(
         chain.state,
         get_last_256_block_hashes(chain),
@@ -197,8 +195,6 @@ def state_transition(chain: BlockChain, block: Block) -> None:
     ensure(receipt_root == block.header.receipt_root, InvalidBlock)
     ensure(block_logs_bloom == block.header.bloom, InvalidBlock)
     ensure(withdrawals_root == block.header.withdrawals_root, InvalidBlock)
-    ensure(inclusion_list_summary_root == block.header.inclusion_list_summary_root, InvalidBlock)
-    ensure(inclusion_list_exclusions_root == block.header.inclusion_list_exclusions_root, InvalidBlock)
 
     chain.blocks.append(block)
     if len(chain.blocks) > 255:

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -221,7 +221,6 @@ class Header:
     base_fee_per_gas: Uint
     withdrawals_root: Root
     inclusion_list_summary_root: Root     # [New in EIP7547]
-    inclusion_list_exclusions_root: Root  # [New in EIP7547]
 
 
 @slotted_freezable
@@ -236,7 +235,6 @@ class Block:
     ommers: Tuple[Header, ...]
     withdrawals: Tuple[Withdrawal, ...]
     inclusion_list_summary: Tuple[InclusionListSummaryEntry, ...]  # [New in EIP7547]
-    inclusion_list_exclusions: Tuple[Uint, ...]                    # [New in EIP7547]
 
 
 @slotted_freezable

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -185,6 +185,16 @@ class Withdrawal:
     address: Address
     amount: U256
 
+@slotted_freezable
+@dataclass
+class InclusionListSummaryEntry:
+    """
+    Inclusion list entries  that have been validated on the consensus layer.
+    """
+
+    address: Address
+    gas_limit: Uint
+
 
 @slotted_freezable
 @dataclass
@@ -210,6 +220,8 @@ class Header:
     nonce: Bytes8
     base_fee_per_gas: Uint
     withdrawals_root: Root
+    inclusion_list_summary_root: Root     # [New in EIP7547]
+    inclusion_list_exclusions_root: Root  # [New in EIP7547]
 
 
 @slotted_freezable
@@ -223,6 +235,8 @@ class Block:
     transactions: Tuple[Union[Bytes, LegacyTransaction], ...]
     ommers: Tuple[Header, ...]
     withdrawals: Tuple[Withdrawal, ...]
+    inclusion_list_summary: Tuple[InclusionListSummaryEntry, ...]  # [New in EIP7547]
+    inclusion_list_exclusions: Tuple[Uint, ...]                    # [New in EIP7547]
 
 
 @slotted_freezable

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -193,8 +193,6 @@ class InclusionListSummaryEntry:
     """
 
     address: Address
-    gas_limit: Uint
-
 
 @slotted_freezable
 @dataclass

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -189,7 +189,7 @@ class Withdrawal:
 @dataclass
 class InclusionListSummaryEntry:
     """
-    Inclusion list entries  that have been validated on the consensus layer.
+    Inclusion list entries that have been validated on the consensus layer.
     """
 
     address: Address

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -187,15 +187,6 @@ class Withdrawal:
 
 @slotted_freezable
 @dataclass
-class InclusionListSummaryEntry:
-    """
-    Inclusion list entries that have been validated on the consensus layer.
-    """
-
-    address: Address
-
-@slotted_freezable
-@dataclass
 class Header:
     """
     Header portion of a block on the chain.
@@ -232,7 +223,7 @@ class Block:
     transactions: Tuple[Union[Bytes, LegacyTransaction], ...]
     ommers: Tuple[Header, ...]
     withdrawals: Tuple[Withdrawal, ...]
-    inclusion_list_summary: Tuple[InclusionListSummaryEntry, ...]  # [New in EIP7547]
+    inclusion_list_summary: Tuple[Address, ...]  # [New in EIP7547]
 
 
 @slotted_freezable

--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -212,6 +212,24 @@ class Header:
     inclusion_list_summary_root: Root     # [New in EIP7547]
 
 
+@dataclass
+class InclusionListSummaryEntry:
+    """
+    A commitment to an address and nonce pair.
+    """
+    address: Address
+    nonce: U64
+
+@dataclass
+class InclusionListSummary:
+    """
+    Full inclusion list summary.
+    """
+    slot: U64
+    proposer_index: U64
+    parent_hash: Hash32
+    summary: Tuple[InclusionListSummaryEntry, ...]
+
 @slotted_freezable
 @dataclass
 class Block:
@@ -223,7 +241,7 @@ class Block:
     transactions: Tuple[Union[Bytes, LegacyTransaction], ...]
     ommers: Tuple[Header, ...]
     withdrawals: Tuple[Withdrawal, ...]
-    inclusion_list_summary: Tuple[Address, ...]  # [New in EIP7547]
+    inclusion_list_summary: InclusionListSummary  # [New in EIP7547]
 
 
 @slotted_freezable


### PR DESCRIPTION
**Overview:** Update `state_transition` and `apply_body` to make IL checks part of block validation.

Note some pulled from https://github.com/ethereum/execution-specs/compare/master...fradamt:execution-specs:eip-7547.

**Itemized:**
- `fork_types.py`
    - Create `InclusionListSummaryEntry` and `InclusionListSummary`
    - Add inclusion list fields to both the `Header` (`ExecutionPayloadHeader` in the CL spec) and `Block` (`ExecutionPayload` in the CL spec) types.
- Update `state_transition` to pass the IL summary to `apply_body`.
- Update `apply_body` (called from `state_transition`) to calculate the added gas from the inclusion list and assert that the inclusion list entries are satisfied.