### PR TITLE
Remove `inclusion_list_exclusions` and simplify logic

### DIFF
--- a/src/ethereum/shanghai/fork_types.py
+++ b/src/ethereum/shanghai/fork_types.py
@@ -221,7 +221,6 @@ class Header:
     base_fee_per_gas: Uint
     withdrawals_root: Root
     inclusion_list_summary_root: Root     # [New in EIP7547]
-    inclusion_list_exclusions_root: Root  # [New in EIP7547]
 
 
 @slotted_freezable
@@ -236,7 +235,6 @@ class Block:
     ommers: Tuple[Header, ...]
     withdrawals: Tuple[Withdrawal, ...]
     inclusion_list_summary: Tuple[InclusionListSummaryEntry, ...]  # [New in EIP7547]
-    inclusion_list_exclusions: Tuple[Uint, ...]                    # [New in EIP7547]
 
 
 @slotted_freezable


### PR DESCRIPTION
The main change is passing the following filtered version of `inclusion_list_summary` to `apply_body`, without any entries which are satisfied by the previous block, and as a consequence doing away with `inclusion_list_exclusions`.

```python
    parent_transactions_addresses = set(decode_transaction(tx).address for tx in parent.transactions)
    inclusion_list_summary = [entry for entry in block.inclusion_list_summary 
                              if entry.address not in parent_transactions_addresses]
```

`inclusions_list_exclusions` is an optimization making it so that only the builder of the block has to go through `parent_transactions`, while everyone else can just use the provided `inclusion_list_exclusions` and do simple checks to verify them against the `parent_transactions`. I would at this point just go for simplicity, and only add back exclusions later if needed/desired.

Another change is simplifying the logic in `apply_body`, aiming for readability and leaving simple optimizations up to implementers. 
